### PR TITLE
Update DaggerfallBillboard.cs

### DIFF
--- a/Assets/Scripts/Internal/DaggerfallBillboard.cs
+++ b/Assets/Scripts/Internal/DaggerfallBillboard.cs
@@ -439,6 +439,26 @@ namespace DaggerfallWorkshop
                 }
             }
         }
+        /// <summary>
+        /// Draws a circle at the bottom of the bilboard to make it easier to judge the size regardless of rotation.
+        /// </summary>
+        public void OnDrawGizmosSelected()
+        {
+            if (!Application.isPlaying)
+            {
+                UnityEditor.SceneView sceneView = GetActiveSceneView();
+                if (sceneView)
+                {
+                    float radius;
+                    Vector3 offset = Vector3.zero;
+
+                    radius = (summary.Size.x / 2);
+                    offset.y = (summary.Size.y / 2);
+
+                    Handles.DrawWireDisc(transform.position - offset, Vector3.up, radius);
+                }
+            }
+        }
 
         private SceneView GetActiveSceneView()
         {


### PR DESCRIPTION
I was watching a stream by Cliffworms where he was using the world data editor to place items and I thought it might be helpful to have a bounding circle displayed at the bottom of billboards to make it easier to see how big they are.  I tried to match the existing code style as closely as possible so hopefully it's not too bad.